### PR TITLE
Update README.md with proper environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ be set in the `sensu-backend` environment:
      runtime_assets:
      - sensu-go-remediation-handler
      env_vars:
-     - "SENSU_BACKEND_HOST=127.0.0.1"
-     - "SENSU_BACKEND_PORT=8080"
-     - "SENSU_USER=remediation-handler"
-     - "SENSU_PASS=supersecret"
+     - "SENSU_API_URL=http://127.0.0.1:8080"
+     - "SENSU_API_CERT_FILE="
+     - "SENSU_API_USER=remediation-handler"
+     - "SENSU_API_PASS=supersecret"
    ```
 
    Save this definition to a file named `sensu-go-remediation-handler.yaml` and


### PR DESCRIPTION
Fixed the `env_vars` in the Handler definition in the example.

Looks like the change was made during [this commit](https://github.com/calebhailey/sensu-go-remediation-handler/commit/1be18af7b9548507f203179247f77dfa28571c75#diff-7ddfb3e035b42cd70649cc33393fe32c).