### PR TITLE
BREAKING CHANGE: use io.sensu.remediation.config.actions annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ metadata:
   labels:
     foo: bar
   annotations:
-    sensu.io/plugins/remediation/config/actions: |
+    io.sensu.remediation.config.actions: |
       [
         {
           "description": "Perform this action once after Nginx has been down for 30 seconds.",

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 	var stdin *os.File
 	var event types.Event
 	var actions []RemediationConfig
-	var annotationConfigKey string = "sensu.io/plugins/remediation/config/actions"
+	var annotationConfigKey string = "io.sensu.remediation.config.actions"
 	var httpClient *http.Client = initHttpClient()
 
 	stdin = os.Stdin

--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func main() {
 		}
 	} else {
 		// No configured actions
-		log.Printf("No remediation actions configured; nothing to do.")
-		log.Printf("To enable remediation actions, configure the \"%s\" check annotation.", annotationConfigKey)
+		log.Printf("No remediation actions configured for check \"%s\"; nothing to do.", event.Check.Name)
+		log.Printf("To enable remediation actions, provide remediation configuration using the \"%s\" check annotation.", annotationConfigKey)
 	}
 }

--- a/testing/data/example-event.json
+++ b/testing/data/example-event.json
@@ -182,7 +182,7 @@
         "foo": "bar"
       },
       "annotations": {
-        "sensu.io/plugins/remediation/config/actions": "[\n  {\n    \"request\": \"remediation-1\",\n    \"occurrences\": [ 3 ],\n    \"severities\": [ 1, 2 ]\n  }\n]\n"
+        "io.sensu.remediation.config.actions": "[\n  {\n    \"request\": \"remediation-1\",\n    \"occurrences\": [ 3 ],\n    \"severities\": [ 1, 2 ]\n  }\n]\n"
       }
     }
   },

--- a/testing/data/example-noop-event.json
+++ b/testing/data/example-noop-event.json
@@ -1,0 +1,189 @@
+{
+  "timestamp": 1548109478,
+  "entity": {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "21b4467341ad",
+      "os": "linux",
+      "platform": "debian",
+      "platform_family": "debian",
+      "platform_version": "9.6",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "02:42:ac:15:00:07",
+            "addresses": [
+              "172.21.0.7/16"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64"
+    },
+    "subscriptions": [
+      "linux",
+      "docker",
+      "poller",
+      "entity:21b4467341ad"
+    ],
+    "last_seen": 1548099786,
+    "deregister": true,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "21b4467341ad",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1"
+      }
+    }
+  },
+  "check": {
+    "command": "echo \"Hello linux world!\" && exit 1",
+    "handlers": [
+      "remediation"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 10,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": null,
+    "subscriptions": [
+      "linux"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "duration": 0.005119243,
+    "executed": 1548109478,
+    "history": [
+      {
+        "status": 1,
+        "executed": 1548109285
+      },
+      {
+        "status": 1,
+        "executed": 1548109295
+      },
+      {
+        "status": 1,
+        "executed": 1548109305
+      },
+      {
+        "status": 1,
+        "executed": 1548109315
+      },
+      {
+        "status": 1,
+        "executed": 1548109325
+      },
+      {
+        "status": 1,
+        "executed": 1548109335
+      },
+      {
+        "status": 1,
+        "executed": 1548109345
+      },
+      {
+        "status": 1,
+        "executed": 1548109355
+      },
+      {
+        "status": 1,
+        "executed": 1548109365
+      },
+      {
+        "status": 1,
+        "executed": 1548109375
+      },
+      {
+        "status": 1,
+        "executed": 1548109385
+      },
+      {
+        "status": 1,
+        "executed": 1548109395
+      },
+      {
+        "status": 1,
+        "executed": 1548109405
+      },
+      {
+        "status": 1,
+        "executed": 1548109415
+      },
+      {
+        "status": 1,
+        "executed": 1548109425
+      },
+      {
+        "status": 1,
+        "executed": 1548109435
+      },
+      {
+        "status": 1,
+        "executed": 1548109445
+      },
+      {
+        "status": 1,
+        "executed": 1548109455
+      },
+      {
+        "status": 1,
+        "executed": 1548109458
+      },
+      {
+        "status": 1,
+        "executed": 1548109468
+      },
+      {
+        "status": 1,
+        "executed": 1548109478
+      }
+    ],
+    "issued": 1548109478,
+    "output": "Hello linux world!\n",
+    "state": "failing",
+    "status": 1,
+    "total_state_change": 0,
+    "last_ok": 1548105266,
+    "occurrences": 3,
+    "occurrences_watermark": 423,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "helloworld",
+      "namespace": "default",
+      "labels": {
+        "foo": "bar"
+      }
+    }
+  },
+  "metadata": {
+    "namespace": "default"
+  }
+}

--- a/testing/manifests/remediation.yaml
+++ b/testing/manifests/remediation.yaml
@@ -89,7 +89,7 @@ metadata:
   labels:
     foo: bar
   annotations:
-    sensu.io/plugins/remediation/config/actions: |
+    io.sensu.remediation.config.actions: |
       [
         {
           "description": "Perform this action after the check has been failing for 30 seconds.",


### PR DESCRIPTION
In the interests of consistency with the `io.sensu` annotations being used by Bonsai and other Sensu projects, this PR makes a breaking change to the check annotation key honored by the handler plugin.

Existing users, please modify your check configurations to use the new `io.sensu.remediation.config.actions` annotation; the old annotation is not supported.